### PR TITLE
1810

### DIFF
--- a/viaplayerAll.js
+++ b/viaplayerAll.js
@@ -311,6 +311,5 @@ var viaplayer = {
 	  let i=(event.clientX-left+document.documentElement.scrollLeft)/oDiv.offsetWidth;
 	  document.querySelector(obj+'>span').style.width = i*100+'%';
 	  this.audio.volume = i;
-	  //this.audioCurrentTime((event.clientX-left+document.documentElement.scrollLeft)/oDiv.offsetWidth)
 	} 
 }


### PR DESCRIPTION
修复IE浏览器不兼容,原因是IE全系浏览器不支持``字符串标识符,修复ie下歌词不滚动
**最大兼容ie为ie9**